### PR TITLE
- updated the PaaS to support extra cert-resolver parameters

### DIFF
--- a/app/application.go
+++ b/app/application.go
@@ -67,6 +67,7 @@ func (sr *ServiceResources) Initialize() {
 			sr.parameters.Https,
 			sr.parameters.CertResolverName,
 			sr.parameters.CertResolverEmail,
+			sr.parameters.CertificateResolverParameters,
 			sr.provider))
 	}
 	sr.appservice = apps.NewService(sr.provider, sr.hasher, apps.NewRepository(sr.dataSource))

--- a/app/core/configuration/base.go
+++ b/app/core/configuration/base.go
@@ -23,6 +23,7 @@ type Configuration struct {
 	Https                          bool                           `yaml:"https"`
 	CertResolverName               string                         `yaml:"cert-resolver-name"`
 	CertResolverEmail              string                         `yaml:"cert-resolver-email"`
+	CertificateResolverParameters  map[string]string              `yaml:"cert-resolver-parameters"`
 	SessionDuration                int                            `yaml:"admin-session-duration"`
 	EncryptionParameters           *security.EncryptionParameters `yaml:"encryption"`
 	AgentParameters                *providers.ClientConfiguration `yaml:"agent-client"`

--- a/app/core/plugins/traefik.go
+++ b/app/core/plugins/traefik.go
@@ -20,21 +20,23 @@ var (
 )
 
 type TraefikPlugin struct {
-	https             bool
-	certResolverName  string
-	certResolverEmail string
-	domain            string
-	network           string
-	provider          providers.Provider
-	identifier        string
+	https                  bool
+	certResolverName       string
+	certResolverEmail      string
+	certResolverParameters map[string]string
+	domain                 string
+	network                string
+	provider               providers.Provider
+	identifier             string
 }
 
-func NewTraefikPlugin(network, domain string, https bool, certResolverName, certResolverEmail string, provider providers.Provider) Plugin {
+func NewTraefikPlugin(network, domain string, https bool, certResolverName, certResolverEmail string, certResolverParameters map[string]string, provider providers.Provider) Plugin {
 	instance := new(TraefikPlugin)
 	instance.network = network
 	instance.https = https
 	instance.certResolverName = certResolverName
 	instance.certResolverEmail = certResolverEmail
+	instance.certResolverParameters = certResolverParameters
 	instance.domain = domain
 	instance.provider = provider
 	return instance
@@ -62,13 +64,14 @@ func (tp *TraefikPlugin) OnStartUp() error {
 		ports = append(ports, 443)
 	}
 	if identifier, err := tp.provider.DeployDependency(&providers.DependencyOrder{
-		ID:      "traefik-plugin",
-		Name:    "internal-traefik-proxy",
-		URI:     "traefik:2.9.5",
-		Digest:  "sha256:6c37f2135af79e0c2e387653ff3ab9abf95eb393439f07cfcfa5e06fd4bb10bb",
-		Ports:   ports,
-		Volumes: tp.mounts(),
-		Command: tp.commands(),
+		ID:                   "traefik-plugin",
+		Name:                 "internal-traefik-proxy",
+		URI:                  "traefik:2.9.6",
+		Digest:               "sha256:0f22b9ca5a3bacd50c43ca193e1970d825fe2320ffc6222fec1e2e81b9a23393",
+		Ports:                ports,
+		Volumes:              tp.mounts(),
+		Command:              tp.commands(),
+		EnvironmentVariables: tp.certResolverParameters,
 	}); err != nil {
 		return err
 	} else {

--- a/app/core/providers/contracts.go
+++ b/app/core/providers/contracts.go
@@ -129,13 +129,14 @@ type NodeDetails struct {
 }
 
 type DependencyOrder struct {
-	ID      string
-	Name    string
-	URI     string
-	Digest  string
-	Ports   []int
-	Volumes map[string]string
-	Command []string
+	ID                   string
+	Name                 string
+	URI                  string
+	Digest               string
+	Ports                []int
+	Volumes              map[string]string
+	Command              []string
+	EnvironmentVariables map[string]string
 }
 
 func (o *DependencyOrder) Image(digest string) string {

--- a/resources/settings.yml
+++ b/resources/settings.yml
@@ -11,6 +11,8 @@ port: 1200
 https: false
 cert-resolver-name: letsencrypt
 cert-resolver-email: email.com
+cert-resolver-parameters:
+  key: val
 network-name: default
 network-prefix: aurora
 plugins:


### PR DESCRIPTION
- updated traefik version
- added extra parameters for certificate-resolver [ENV-VARS]
- partial fixes to remote client `Still failing` connection, now proxy fix at the moment
- fixed errors in container tracking and updates